### PR TITLE
American political party sanity check

### DIFF
--- a/CWE/common/countries/USA.txt
+++ b/CWE/common/countries/USA.txt
@@ -12,21 +12,10 @@ party = {
 	trade_policy = free_trade
 	war_policy = jingoism
 	start_date = 1836.1.1
-	end_date = 1964.1.1
-}
-party = {
-	name = "American Independent Party"
-	citizenship_policy = residency
-	economic_policy = interventionism
-	ideology = nationalist
-	religious_policy = moralism
-	trade_policy = free_trade
-	war_policy = jingoism
-	start_date = 1964.1.1
 	end_date = 1973.1.1
 }
 party = {
-	name = "Republican Party (Supremacists)"
+	name = "Republican Party (Nationalist)"
 	citizenship_policy = residency
 	economic_policy = interventionism
 	ideology = nationalist
@@ -34,22 +23,10 @@ party = {
 	trade_policy = free_trade
 	war_policy = jingoism
 	start_date = 1973.1.1
-	end_date = 2010.1.1
-}
-party = {
-	name = "American Freedom Party"
-	citizenship_policy = residency
-	economic_policy = interventionism
-	ideology = nationalist
-	religious_policy = moralism
-	trade_policy = protectionism
-	war_policy = jingoism
-	start_date = 2010.1.1
 	end_date = 2100.1.1
 }
-
 party = {
-	name = "Democratic Party (Truman)"
+	name = "Democratic Party (Moderates)"
 	citizenship_policy = limited_citizenship
 	economic_policy = interventionism
 	ideology = big_tent
@@ -57,17 +34,6 @@ party = {
 	trade_policy = free_trade
 	war_policy = pro_military
 	start_date = 1932.1.1
-	end_date = 1953.1.1
-}
-party = {
-	name = "Republican Party (Eisenhower)"
-	citizenship_policy = limited_citizenship
-	economic_policy = interventionism
-	ideology = big_tent
-	religious_policy = secularized
-	trade_policy = free_trade
-	war_policy = pro_military
-	start_date = 1953.1.1
 	end_date = 1961.1.1
 }
 party = {
@@ -82,7 +48,7 @@ party = {
 	end_date = 2009.1.1
 }
 party = {
-	name = "Democratic Party (Obama-Biden)"
+	name = "Democratic Party (Centrists)"
 	citizenship_policy = full_citizenship
 	economic_policy = interventionism
 	ideology = big_tent
@@ -90,33 +56,10 @@ party = {
 	trade_policy = free_trade
 	war_policy = pro_military
 	start_date = 2009.1.1
-	end_date = 2021.1.1
-}
-party = {
-	name = "Democratic Party (Biden)"
-	citizenship_policy = full_citizenship
-	economic_policy = interventionism
-	ideology = big_tent
-	religious_policy = secularized
-	trade_policy = free_trade
-	war_policy = pro_military
-	start_date = 2021.1.1
-	end_date = 2029.1.1
-}
-party = {
-	name = "Democratic Party (Centrist)"
-	citizenship_policy = full_citizenship
-	economic_policy = interventionism
-	ideology = big_tent
-	religious_policy = secularized
-	trade_policy = free_trade
-	war_policy = pro_military
-	start_date = 2029.1.1
 	end_date = 2092.1.1
 }
-
 party = {
-	name = "Republican Party (Dewey)"
+	name = "Republican Party (Rockefeller Republican)"
 	citizenship_policy = full_citizenship
 	economic_policy = interventionism
 	ideology = conservative
@@ -127,7 +70,7 @@ party = {
 	end_date = 1953.1.1
 }
 party = {
-	name = "Republican Party (MacArthur)"
+	name = "Republican Party (Rockefeller Republican)"
 	citizenship_policy = full_citizenship
 	economic_policy = interventionism
 	ideology = conservative
@@ -138,7 +81,7 @@ party = {
 	end_date = 1961.1.1
 }
 party = {
-	name = "Republican Party (Goldwater)"
+	name = "Republican Party (Rockefeller Republican)"
 	citizenship_policy = limited_citizenship
 	economic_policy = laissez_faire
 	ideology = conservative
@@ -149,7 +92,7 @@ party = {
 	end_date = 1969.1.1
 }
 party = {
-	name = "Republican Party (Nixon)"
+	name = "Republican Party (Nixonian)"
 	citizenship_policy = residency
 	economic_policy = interventionism
 	ideology = conservative
@@ -157,21 +100,10 @@ party = {
 	trade_policy = free_trade
 	war_policy = pro_military
 	start_date = 1969.1.1
-	end_date = 1977.1.1
-}
-party = {
-	name = "Republican Party (Ford)"
-	citizenship_policy = residency
-	economic_policy = interventionism
-	ideology = conservative
-	religious_policy = moralism
-	trade_policy = free_trade
-	war_policy = pro_military
-	start_date = 1977.1.1
 	end_date = 1981.1.1
 }
 party = {
-	name = "Republican Party (Reagan)"
+	name = "Republican Party (Reagan Coalition)"
 	citizenship_policy = residency
 	economic_policy = laissez_faire
 	ideology = conservative
@@ -179,32 +111,10 @@ party = {
 	trade_policy = free_trade
 	war_policy = jingoism
 	start_date = 1981.1.1
-	end_date = 1989.1.1
-}
-party = {
-	name = "Republican Party (Bush Sr.)"
-	citizenship_policy = limited_citizenship
-	economic_policy = interventionism
-	ideology = conservative
-	religious_policy = secularized
-	trade_policy = free_trade
-	war_policy = jingoism
-	start_date = 1989.1.1
-	end_date = 1997.1.1
-}
-party = {
-	name = "Republican Party (Bob Dole)"
-	citizenship_policy = limited_citizenship
-	economic_policy = laissez_faire
-	ideology = conservative
-	religious_policy = secularized
-	trade_policy = free_trade
-	war_policy = pro_military
-	start_date = 1997.1.1
 	end_date = 2001.1.1
 }
 party = {
-	name = "Republican Party (Bush Jr.)"
+	name = "Republican Party (Neoconservative)"
 	citizenship_policy = limited_citizenship
 	economic_policy = laissez_faire
 	ideology = conservative
@@ -212,44 +122,11 @@ party = {
 	trade_policy = free_trade
 	war_policy = jingoism
 	start_date = 2001.1.1
-	end_date = 2009.1.1
-}
-party = {
-	name = "Republican Party (McCain)"
-	citizenship_policy = full_citizenship
-	economic_policy = laissez_faire
-	ideology = conservative
-	religious_policy = moralism
-	trade_policy = free_trade
-	war_policy = jingoism
-	start_date = 2009.1.1
-	end_date = 2017.1.1
-}
-party = {
-	name = "Republican Party (Romney)"
-	citizenship_policy = full_citizenship
-	economic_policy = interventionism
-	ideology = conservative
-	religious_policy = moralism
-	trade_policy = free_trade
-	war_policy = pro_military
-	start_date = 2013.1.1
-	end_date = 2025.1.1
-}
-party = {
-	name = "Republican Party (Moderates)"
-	citizenship_policy = limited_citizenship
-	economic_policy = interventionism
-	ideology = conservative
-	religious_policy = moralism
-	trade_policy = free_trade
-	war_policy = pro_military
-	start_date = 2025.1.1
 	end_date = 2092.1.1
 }
 
 party = {
-	name = "Democratic Party (Liberal)"
+	name = "Democratic Party (New Deal Moderates)"
 	citizenship_policy = limited_citizenship
 	economic_policy = laissez_faire
 	ideology = liberal
@@ -260,7 +137,7 @@ party = {
 	end_date = 1961.1.1
 }
 party = {
-	name = "Democratic Party (Kennedy)"
+	name = "Democratic Party (New Frontier)"
 	citizenship_policy = full_citizenship
 	economic_policy = interventionism
 	ideology = liberal
@@ -271,7 +148,7 @@ party = {
 	end_date = 1969.1.1
 }
 party = {
-	name = "Democratic Party (Humphrey)"
+	name = "Democratic Party (Third Way)"
 	citizenship_policy = full_citizenship
 	economic_policy = interventionism
 	ideology = liberal
@@ -279,88 +156,22 @@ party = {
 	trade_policy = free_trade
 	war_policy = pro_military
 	start_date = 1969.1.1
-	end_date = 1977.1.1
-}
-party = {
-	name = "Democratic Party (Carter)"
-	citizenship_policy = full_citizenship
-	economic_policy = interventionism
-	ideology = liberal
-	religious_policy = secularized
-	trade_policy = free_trade
-	war_policy = pacifism
-	start_date = 1977.1.1
 	end_date = 1985.1.1
 }
 party = {
-	name = "Democratic Party (Dukakis)"
+	name = "Democratic Party (New Democrats)"
 	citizenship_policy = full_citizenship
 	economic_policy = interventionism
 	ideology = liberal
 	religious_policy = secularized
 	trade_policy = free_trade
-	war_policy = pro_military
+	war_policy = jingoism
 	start_date = 1985.1.1
-	end_date = 1993.1.1
-}
-party = {
-	name = "Democratic Party (B. Clinton)"
-	citizenship_policy = full_citizenship
-	economic_policy = laissez_faire
-	ideology = liberal
-	religious_policy = secularized
-	trade_policy = free_trade
-	war_policy = jingoism
-	start_date = 1993.1.1
-	end_date = 2001.1.1
-}
-party = {
-	name = "Democratic Party (Al Gore)"
-	citizenship_policy = full_citizenship
-	economic_policy = interventionism
-	ideology = liberal
-	religious_policy = secularized
-	trade_policy = free_trade
-	war_policy = pro_military
-	start_date = 2001.1.1
-	end_date = 2009.1.1
-}
-party = {
-	name = "Democratic Party (Obama)"
-	citizenship_policy = full_citizenship
-	economic_policy = interventionism
-	ideology = liberal
-	religious_policy = secularized
-	trade_policy = free_trade
-	war_policy = pro_military
-	start_date = 2009.1.1
-	end_date = 2017.1.1
-}
-party = {
-	name = "Democratic Party (H. Clinton)"
-	citizenship_policy = full_citizenship
-	economic_policy = interventionism
-	ideology = liberal
-	religious_policy = secularized
-	trade_policy = free_trade
-	war_policy = jingoism
-	start_date = 2017.1.1
-	end_date = 2025.1.1
-}
-party = {
-	name = "Democratic Party (Moderates)"
-	citizenship_policy = full_citizenship
-	economic_policy = interventionism
-	ideology = liberal
-	religious_policy = secularized
-	trade_policy = free_trade
-	war_policy = pro_military
-	start_date = 2025.1.1
 	end_date = 2092.1.1
 }
 
 party = {
-	name = "Democratic Party (States' Rights)"
+	name = "Democratic Party (Dixiecrats)"
 	citizenship_policy = residency
 	economic_policy = laissez_faire
 	ideology = populist
@@ -368,21 +179,10 @@ party = {
 	trade_policy = free_trade
 	war_policy = jingoism
 	start_date = 1836.1.1
-	end_date = 1960.1.1
-}
-party = {
-	name = "Democratic Party (Wallace)"
-	citizenship_policy = residency
-	economic_policy = laissez_faire
-	ideology = populist
-	religious_policy = moralism
-	trade_policy = free_trade
-	war_policy = jingoism
-	start_date = 1960.1.1
 	end_date = 1965.1.1
 }
 party = {
-	name = "American Independent Party"
+	name = "Republican Party (Dixiecrats)"
 	citizenship_policy = residency
 	economic_policy = laissez_faire
 	ideology = populist
@@ -390,17 +190,6 @@ party = {
 	trade_policy = free_trade
 	war_policy = jingoism
 	start_date = 1965.1.1
-	end_date = 1976.1.1
-}
-party = {
-	name = "Republican Party (Dixiecrats)"
-	citizenship_policy = limited_citizenship
-	economic_policy = laissez_faire
-	ideology = populist
-	religious_policy = moralism
-	trade_policy = free_trade
-	war_policy = jingoism
-	start_date = 1976.1.1
 	end_date = 1990.1.1
 }
 party = {
@@ -415,7 +204,7 @@ party = {
 	end_date = 2016.1.1
 }
 party = {
-	name = "Republican Party (Trump)"
+	name = "Republican Party (Trumpist)"
 	citizenship_policy = residency
 	economic_policy = laissez_faire
 	ideology = populist
@@ -423,25 +212,14 @@ party = {
 	trade_policy = protectionism
 	war_policy = jingoism
 	start_date = 2016.1.1
-	end_date = 2029.1.1
-}
-party = {
-	name = "Republican Party (Trumpist)"
-	citizenship_policy = residency
-	economic_policy = interventionism
-	ideology = populist
-	religious_policy = moralism
-	trade_policy = protectionism
-	war_policy = jingoism
-	start_date = 2029.1.1
 	end_date = 2092.1.1
 }
 
 party = {
-	name = "Democratic Party (Left-Wing)"
+	name = "Democratic Party (New Deal Radicals)"
 	citizenship_policy = full_citizenship
 	economic_policy = state_capitalism
-	ideology = socialist
+	ideology = socialist #Social_democrat
 	religious_policy = secularized
 	trade_policy = protectionism
 	war_policy = pro_military
@@ -449,10 +227,10 @@ party = {
 	end_date = 1961.1.1
 }
 party = {
-	name = "Democratic Party (Johnson)"
+	name = "Democratic Party (Great Society)"
 	citizenship_policy = full_citizenship
 	economic_policy = interventionism
-	ideology = socialist
+	ideology = socialist #Social_democrat
 	religious_policy = moralism
 	trade_policy = free_trade
 	war_policy = pro_military
@@ -460,28 +238,27 @@ party = {
 	end_date = 1973.5.30
 }
 party = {
-	name = "Democratic Party (Sanders)"
+	name = "Democratic Party (DSOC)"
 	citizenship_policy = full_citizenship
 	economic_policy = state_capitalism
-	ideology = socialist
+	ideology = socialist #Social_democrat
 	religious_policy = pro_atheism
 	trade_policy = protectionism
 	war_policy = pacifism
 	start_date = 1973.5.30
-	end_date = 2025.1.1
+	end_date = 1982.3.20
 }
 party = {
-	name = "Democratic Party (Socialists)"
+	name = "Democratic Party (DSA)"
 	citizenship_policy = full_citizenship
 	economic_policy = state_capitalism
-	ideology = socialist
-	religious_policy = pro_atheism
+	ideology = socialist #Social_democrat
+	religious_policy = secularized
 	trade_policy = protectionism
-	war_policy = pro_military
-	start_date = 2025.1.1
+	war_policy = pacifism
+	start_date = 1982.3.20
 	end_date = 2092.1.1
 }
-
 party = {
 	name = "Democratic Party (PDA)"
 	citizenship_policy = full_citizenship
@@ -494,7 +271,7 @@ party = {
 	end_date = 2018.1.1
 }
 party = {
-	name = "Democratic Party (Progressives)"
+	name = "Democratic Party (Progressive Caucus)"
 	citizenship_policy = full_citizenship
 	economic_policy = state_capitalism
 	ideology = progressive
@@ -506,7 +283,7 @@ party = {
 }
 
 party = {
-	name = "Democratic Party (Conservatives)"
+	name = "Democratic Party (Evangelicals)"
 	citizenship_policy = residency
 	economic_policy = laissez_faire
 	ideology = traditionalist 
@@ -517,36 +294,14 @@ party = {
 	end_date = 1976.1.1
 }
 party = {
-	name = "Republican Party (Conservatives)"
-	citizenship_policy = residency
-	economic_policy = laissez_faire
-	ideology = traditionalist 
-	religious_policy = moralism 
-	trade_policy = free_trade
-	war_policy = jingoism
-	start_date = 1976.1.1
-	end_date = 2016.1.1
-}
-party = {
-	name = "Republican Party (Pence)"
-	citizenship_policy = limited_citizenship
-	economic_policy = interventionism
-	ideology = traditionalist 
-	religious_policy = moralism 
-	trade_policy = protectionism
-	war_policy = pro_military
-	start_date = 2016.1.1
-	end_date = 2032.1.1
-}
-party = {
 	name = "Republican Party (Evangelicals)"
 	citizenship_policy = limited_citizenship
 	economic_policy = interventionism
 	ideology = traditionalist 
 	religious_policy = moralism 
 	trade_policy = protectionism
-	war_policy = jingoism
-	start_date = 2032.1.1
+	war_policy = pro_military
+	start_date = 1976.1.1
 	end_date = 2092.1.1
 }
 

--- a/CWE/events/usa_elections.txt
+++ b/CWE/events/usa_elections.txt
@@ -1990,7 +1990,7 @@ country_event = {
 		ai_chance = {
 			factor = 0.5
 			modifier = {
-				factor = = 3
+				factor = 3
 				pop_majority_ideology = liberal
 			}
 			modifier = {
@@ -2137,7 +2137,7 @@ country_event = {
 		ai_chance = {
 			factor = 0.5
 			modifier = {
-				factor = .=3
+				factor = 3
 				pop_majority_ideology = liberal
 			}
 			modifier = {
@@ -2203,7 +2203,7 @@ country_event = {
 		ai_chance = {
 			factor = 0.5
 			modifier = {
-				factor = = 3
+				factor = 3
 				pop_majority_ideology = liberal
 			}
 			modifier = {

--- a/CWE/history/countries/USA - USA.txt
+++ b/CWE/history/countries/USA - USA.txt
@@ -11,7 +11,7 @@ non_state_culture_literacy = 0.0
 civilized = yes
 prestige = 6000
 last_election = 1942.11.3
-ruling_party = "Democratic Party (Truman)"
+ruling_party = "Democratic Party (Moderates)"
 upper_house = {
 	populist = 0
 	big_tent = 46
@@ -101,7 +101,7 @@ oob = "/USA_oob.txt"
 
 	remove_accepted_culture = german
 	
-	ruling_party = "Democratic Party (Truman)"
+	ruling_party = "Democratic Party (Moderates)"
 	
 	union_rights = restricted_unions
 	
@@ -126,7 +126,7 @@ oob = "/USA_oob.txt"
 	non_state_culture_literacy = 0.15
 	civilized = yes
 	prestige = 6500
-	ruling_party = "Republican Party (Bush Sr.)"
+	ruling_party = "Republican Party (Reagan Coalition)"
 	upper_house = {
 		populist = 0
 		liberal = 57


### PR DESCRIPTION
-Making American Political Parties based on factions instead of people, reducing the number and making who exactly is in charge more straight-forward at a glance.